### PR TITLE
[fix] compatibility with classic Dirt, sample_n loops to avoid crash

### DIFF
--- a/SampleBank.js
+++ b/SampleBank.js
@@ -71,7 +71,8 @@ SampleBank.prototype.load = function(name,number) {
 SampleBank.prototype.getBuffer = function(name,number) {
   if(this.sampleMap == null) throw Error("SampleBank.getBuffer: sampleMap is null");
   if(this.sampleMap[name] == null) throw Error("SampleBank.getBuffer: no sampleMap for " + name);
-  if(number >= this.sampleMap[name].length) throw Error("SampleBank.getBuffer: number > number of samples");
+  number = number % this.sampleMap[name].length;
+
   var filename = this.sampleMap[name][number];
   if(this.samples[filename] == null) {
     this.load(name,number);


### PR DESCRIPTION
e.g if you request a sample playback with sample_n = 9 but there are only 9 samples, sample 0 is picked, i.e. the sample_n value loops over just as classic dirt does.
