### PR TITLE
Fix disconnect node

### DIFF
--- a/Graph.js
+++ b/Graph.js
@@ -92,7 +92,7 @@ function Graph(msg,ac,sampleBank){
 	//this is necessary or the processor node's (coarseNode's) handler
 	//function will infinitely be invoked
 	last.onended=function(){
-		last.disconnect(coarseNode)
+	    if (last !== coarseNode) { last.disconnect(coarseNode) }
 		coarseNode.disconnect()
 	}
 
@@ -111,7 +111,7 @@ function Graph(msg,ac,sampleBank){
 	else crushNode = coarseNode;
 
 	coarseNode.onended = function(){
-		coarseNode.disconnect(crushNode)
+	    if (coarseNode !== crushNode) {coarseNode.disconnect(crushNode)}
 		crushNode.disconnect();
 	}
 

--- a/SampleBank.js
+++ b/SampleBank.js
@@ -71,7 +71,8 @@ SampleBank.prototype.load = function(name,number) {
 SampleBank.prototype.getBuffer = function(name,number) {
   if(this.sampleMap == null) throw Error("SampleBank.getBuffer: sampleMap is null");
   if(this.sampleMap[name] == null) throw Error("SampleBank.getBuffer: no sampleMap for " + name);
-  if(number >= this.sampleMap[name].length) throw Error("SampleBank.getBuffer: number > number of samples");
+  number = number % this.sampleMap[name].length;
+
   var filename = this.sampleMap[name][number];
   if(this.samples[filename] == null) {
     this.load(name,number);


### PR DESCRIPTION
avoid trying to disconnect a node from itself (applies to coarse and crush handling if they are not used)

Without this you might get an `InvalidAccessError` when not using crush or coarse.

also Crush and Coarse seem broken, as ScriptProcessorNode can not be stopped cleanly (as the inline comments suggest)

I might have to redo this pull request as it currently contains the code for #3 as well, maybe this is not necessary when #3 is merged
